### PR TITLE
Redesign and Add sections to documentation

### DIFF
--- a/content/en/documentation/install-apptainer/howto.md
+++ b/content/en/documentation/install-apptainer/howto.md
@@ -122,4 +122,23 @@ curl -s https://raw.githubusercontent.com/apptainer/apptainer/main/tools/install
 
 Please note the global `apptainer` command will not be available with this installation, and it is required to call the executable using `install-dir/bin/apptainer`. We suggest to create an `apptainer` alias pointing to this executable in `~/.bashrc` or `~/.bash_aliases`.
 
+## Install on Windows/MacOS
+
+The latest versions of Windows (build 19041 and above) offer the ability to use Linux virtual machines in the Windows environment via WSL2 (for Windows Subsystem for Linux). WSL2 is installed by running the following command in a Powershell prompt as an administrator:
+
+```bash
+wsl --install
+``` 
+
+After running the command, the machine must be rebooted. Next, use the following commands to configure your working environment:
+
+```bash
+wsl.exe --install Ubuntu-24.04 # to install Ubuntu-24-04
+wsl --set-default Ubuntu-24-04 # to set the Ubuntu-24.04 image as the default image
+```
+
+The last command is particularly important if you are also using Docker Desktop on your machine. During the installation of the Ubuntu-24.04 image, you will be asked to enter a user login and password. Once these operations have been completed, you can access the Ubuntu-24.04 environment by running the `wsl.exe` command in a Powershell or Windows terminal. Finally, you can repeat the 'Installing Debian packages' steps to install and use Apptainer.
+
+For Mac users, it is recommended to use Lima via Homebrew on the [Apptainer documentation](apptainer.org/docs/admin/main/installation.html#mac).
+
 </div>

--- a/content/fr/documentation/install-apptainer/howto.md
+++ b/content/fr/documentation/install-apptainer/howto.md
@@ -10,7 +10,7 @@ weight: 1
 
 Ce tutoriel présente succinctement le processus d'installation du logiciel de conteneurisation [Apptainer](https://apptainer.org/). Il est d'ailleurs largement basé sur les [instructions d'installations officielles](https://apptainer.org/docs/admin/1.2/installation.html#install-from-pre-built-packages), et nous vous invitons à consulter ces ressources pour plus de détails.
 
-Le logiciel fonctionne sur toute distribution Linux moderne ; il ne tourne pas de façon native sur Windows et MacOS, n'étant pas compatible avec les noyaux de ces systèmes d'exploitation. Pour ces plateformes, une solution de machine virtuelle est préconisée et ne sera pas couverte ici : plus d'informations [ici](https://apptainer.org/docs/admin/1.2/installation.html#installation-on-windows-or-mac).
+Le logiciel fonctionne sur toute distribution Linux moderne ; il ne tourne pas de façon native sur Windows et MacOS, n'étant pas compatible avec les noyaux de ces systèmes d'exploitation. Pour ces plateformes, une solution de machine virtuelle est préconisée : plus d'informations [ici](https://apptainer.org/docs/admin/1.2/installation.html#installation-on-windows-or-mac).
 
 Enfin, ce tutoriel se concentre sur les versions en cours d'exploitation : si vous utilisez une version de distribution Linux qui n'est plus supportée (par exemple CentOS 7 ou Ubuntu 18.04) et que vous rencontrez une erreur difficile à résoudre, n'hésitez pas à [nous contacter](/contact) !
 
@@ -123,5 +123,24 @@ curl -s https://raw.githubusercontent.com/apptainer/apptainer/main/tools/install
 ```
 
 Toutefois, notez que pour exécuter Apptainer, la commande globale n'est pas directement accessible et il faut à la place lancer `install-dir/bin/apptainer`. Nous vous suggérons de créer un alias `apptainer` pointant vers cet exécutable dans votre `~/.bashrc` ou `~/.bash_aliases`.
+
+## Installation sur Windows / MacOS
+
+Les versions les plus récentes de Windows (Build 19041 et ultérieur) offrent la possibilité d'utiliser des machines virtuelles Linux dans l'environnement Windows via WSL2 (pour Windows Subsystem for Linux). L'installation de WSL2 se fait en exécutant la commande suivante dans un prompt Powershell en tant qu'administrateur :
+
+```bash
+wsl --install
+``` 
+
+Une fois la commande effectuée, il faut redémarrer la machine. Ensuite, la configuration de l'environnement de travail se fait avec les commandes suivantes :
+
+```bash
+wsl.exe --install Ubuntu-24.04 # pour installer Ubuntu-24-04
+wsl --set-default Ubuntu-24-04 # pour définir l'image Ubuntu-24.04 comme étant l'image par défaut
+```
+
+La dernière commande est notamment importante si vous utilisez aussi Docker Desktop sur votre machine. Pendant l'installation de l'image Ubuntu-24.04, vous devrez renseigner un identifiant et un mot de passe utilisateur. Une fois ces opérations réalisées, vous pouvez accéder à l'environnement Ubuntu-24.04 en exécutant la commande `wsl.exe` dans un Powershell ou un terminal windows. Enfin, vous pouvez répéter les étapes "Installer les paquets Debian" pour installer, puis utiliser Apptainer.
+
+Pour les utilisateurs Mac, il est recommandé d'utiliser Lima via Homebrew sur la [documentation d'Apptainer](apptainer.org/docs/admin/main/installation.html#mac).
 
 </div>


### PR DESCRIPTION
- [ ] Add "Use Apptainer's image of Aiida" 
- [ ] Add "Use `cp2k` container"
- [ ] Add "Performance benchmarks" (Nix vs Apptainer vs Guix)
- [ ] Add "Performance benchmarks" (Ubuntu vs WSL2)
- [ ] Add "Guix tutorial" (Installation)
- [ ] Add "Guix tutorial" (Basics commands)
- [ ] Add "Guix tutorial" (Add a channel)
- [ ] Add "Guix tutorial" (Use `guix shell` and `guix time-machine`)
- [ ] Add "Gitlab tutorial" (Report a bug)
- [ ] Add "Gitlab tutorial" (Ask a new feature)
- [ ] Add codes wordcloud to Apptainer and Guix sections
- [ ] Add HPC France map to Apptainer and Guix sections
- [ ] Add "FAQ section" (Apptainer in parallel)
- [ ] Add "FAQ section" (Differences between `--containall`, `--contain` and `--cleanenv`)
- [ ] Add "FAQ section" (Run visu apptainer images under Wayland and with supr-user rights)
- [ ] Add "FAQ section" (Run visu apptainer images on head-nodes)