### PR TITLE
Fix internal links

### DIFF
--- a/README.FR.md
+++ b/README.FR.md
@@ -148,7 +148,7 @@ diamond-website/
 ├── .prettierrc.yaml
 ├── CONTRIBUTING.md
 ├── LICENSE
-├── README.EN.md
+├── README.md
 ├── README.FR.md
 ├── hugo_stats.json
 ├── netlify.toml

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ diamond-website/
 ├── .prettierrc.yaml
 ├── CONTRIBUTING.md
 ├── LICENSE
-├── README.EN.md
+├── README.md
 ├── README.FR.md
 ├── hugo_stats.json
 ├── netlify.toml

--- a/content/en/documentation/by-container/aiida.md
+++ b/content/en/documentation/by-container/aiida.md
@@ -7,7 +7,7 @@ weight: 6
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-Before following these instructions, you must have Apptainer installed on your machine; see [this link](/documentation/install/install_apptainer/) for more details.
+Before following these instructions, you must have Apptainer installed on your machine; see [this link](/en/documentation/install/install-apptainer/) for more details.
 
 This tutorial explains how to interact with AiiDA's Apptainer image.
 

--- a/content/en/documentation/by-container/lammps.md
+++ b/content/en/documentation/by-container/lammps.md
@@ -8,7 +8,7 @@ weight: 1
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-In preamble, you need to have Apptainer installed on your machine ; see [this link](/en/documentation/install-apptainer/howto/) for more details.
+In preamble, you need to have Apptainer installed on your machine ; see [this link](/en/documentation/install/install-apptainer/) for more details.
 
 This tutorial focuses on using the LAMMPS container image available at [this address](/en/codes/scientific-computing/lammps/). By following this link, you will get an Apptainer image (`.sif` file format) allowing you to create containers running LAMMPS.
 
@@ -111,7 +111,7 @@ apptainer exec --env OMP_NUM_THREADS=2 $HOME/apptainer-images/lammps.sif mpirun 
 
 In the previous command, we use the `mpirun` command provided by the embedded version of **OpenMPI** in the container to communicate directly with the host machine hardware. This _embedded_ usage has a great advantage, since it uses only the tools installed in the container: it works on all host machines without requiring any installation. However, the version of **OpenMPI** present in the container is not designed to run optimally on all host machines, but to provide satisfactory performance on as wide a range of machines as possible. Typically, in the case of Quantum Espresso, processor utilisation peaks at 85-90% with embedded parallelization. Furthermore, this mode of parallelisation does not allow for distributed computing across multiple compute nodes. While easy porting at the cost of slightly degraded performance may be appropriate for simple testing on a local machine, this is not the case for a high performance computing infrastructure.
 
-In cases where numerical performance is key, we recommend using a hybrid parallelisation mode, where we use the host machine's version of **OpenMPI** as an intermediary between the container's version and the host machine's hardware. See the [dedicated page](/documentation/use/apptainer_parallel/) for more details.
+In cases where numerical performance is key, we recommend using a hybrid parallelisation mode, where we use the host machine's version of **OpenMPI** as an intermediary between the container's version and the host machine's hardware. See the [dedicated page](/en/documentation/use/apptainer-parallel/) for more details.
 
 ### Display help
 

--- a/content/en/documentation/by-container/ovito.md
+++ b/content/en/documentation/by-container/ovito.md
@@ -8,7 +8,7 @@ weight: 2
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-Before proceeding with these explanations, it is necessary to have Apptainer installed on your machine; see [this link](/en/documentation/install-apptainer/howto/) for more details.
+Before proceeding with these explanations, it is necessary to have Apptainer installed on your machine; see [this link](/en/documentation/install/install-apptainer/) for more details.
 
 This tutorial details the usage of the Ovito code container image downloadable at [this address](/en/codes/visualisation/ovito/). By following this link, you retrieve an Apptainer image (file format `.sif`) that allows you to create containers capable of running Ovito.
 

--- a/content/en/documentation/by-container/paraview.md
+++ b/content/en/documentation/by-container/paraview.md
@@ -8,7 +8,7 @@ weight: 4
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-Before proceeding with these explanations, it is necessary to have installed Apptainer on your machine; see [this link](/en/documentation/install-apptainer/howto/) for more details.
+Before proceeding with these explanations, it is necessary to have installed Apptainer on your machine; see [this link](/en/documentation/install/install-apptainer/) for more details.
 
 This tutorial details the usage of the container image of the ParaView code downloadable at [this address](/en/codes/visualisation/paraview/). By following this link, you obtain an Apptainer image (file format `.sif`) that allows you to create containers capable of running ParaView.
 

--- a/content/en/documentation/by-container/quantum-espresso.md
+++ b/content/en/documentation/by-container/quantum-espresso.md
@@ -8,7 +8,7 @@ weight: 3
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-In preamble, you need to have Apptainer installed on your machine; see [this link](/en/documentation/install-apptainer/howto/) for more details.
+In preamble, you need to have Apptainer installed on your machine; see [this link](/en/documentation/install/install-apptainer/) for more details.
 
 This tutorial focuses on using the Quantum Espresso container image available at [this address](/en/codes/scientific-computing/quantum-espresso/). By following this link, you will get an Apptainer image (`.sif` file format) allowing you to create containers running Quantum Espresso.
 

--- a/content/en/documentation/by-container/vmd.md
+++ b/content/en/documentation/by-container/vmd.md
@@ -8,7 +8,7 @@ weight: 4
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-Before proceeding with these explanations, it is necessary to have installed Apptainer on your machine; see [this link](/en/documentation/install-apptainer/howto/) for more details.
+Before proceeding with these explanations, it is necessary to have installed Apptainer on your machine; see [this link](/en/documentation/install/install-apptainer/) for more details.
 
 This tutorial details the usage of the container image of the VMD code downloadable at [this address](/en/codes/visualisation/vmd/). By following this link, you obtain an Apptainer image (file format `.sif`) that allows you to create containers capable of running VMD.
 

--- a/content/en/documentation/install/install-apptainer.md
+++ b/content/en/documentation/install/install-apptainer.md
@@ -143,7 +143,7 @@ Please note the global `apptainer` command will not be available with this insta
 
 ## Install on Windows/MacOS
 
-For Windows user, a dedicated documentation page can be found [here](/en/documentation/install-apptainer/apptainer-windows).
+For Windows user, a dedicated documentation page can be found [here](/en/documentation/install/apptainer-windows/).
 
 For Mac users, it is recommended to use Lima via Homebrew on the [Apptainer documentation](https://apptainer.org/docs/admin/main/installation.html#mac).
 

--- a/content/en/documentation/install/install-guix.md
+++ b/content/en/documentation/install/install-guix.md
@@ -44,7 +44,7 @@ If you're interested in this topic, we recommend you have a look at this [articl
 
 ## Install on Windows / MacOS
 
-For Windows users, you can use a [similar solution](/en/documentation/install/apptainer-windows) to that of Apptainer and use Windows Subsystem for Linux (WSL2). However, installing Guix in WSL is far from trivial. We advise you to follow this [guide](https://gist.github.com/giuliano108/49ec5bd0a9339db98535bc793ceb5ab4).
+For Windows users, you can use a [similar solution](/en/documentation/install/apptainer-windows/) to that of Apptainer and use Windows Subsystem for Linux (WSL2). However, installing Guix in WSL is far from trivial. We advise you to follow this [guide](https://gist.github.com/giuliano108/49ec5bd0a9339db98535bc793ceb5ab4).
 
 For MacOS users, we recommend using a virtual machine or Docker. You can check this [link](https://pagure.io/projects/MSG/%2A).
 

--- a/content/en/documentation/use/apptainer-image.md
+++ b/content/en/documentation/use/apptainer-image.md
@@ -7,7 +7,7 @@ weight: 1
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-In preamble, you need to have Apptainer installed on your machine ; see [this link](/en/documentation/install-apptainer/howto/) for more details.
+In preamble, you need to have Apptainer installed on your machine ; see [this link](/en/documentation/install/install-apptainer/) for more details.
 
 This tutorial explains the main ways to interact with an Apptainer image in order to generate and manage containers. Instructions presented here are in principle also valid for any other Apptainer container.
 

--- a/content/fr/documentation/by-container/aiida.md
+++ b/content/fr/documentation/by-container/aiida.md
@@ -7,7 +7,7 @@ weight: 6
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/documentation/install/install_apptainer/) pour plus de détails.
+En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/fr/documentation/install/install-apptainer/) pour plus de détails.
 
 Ce tutoriel explicite la démarche à suivre pour interagir avec l'image Apptainer d'AiiDA.
 

--- a/content/fr/documentation/by-container/lammps.md
+++ b/content/fr/documentation/by-container/lammps.md
@@ -8,7 +8,7 @@ weight: 1
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/documentation/install/install_apptainer/) pour plus de détails.
+En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/fr/documentation/install/install-apptainer/) pour plus de détails.
 
 Ce tutoriel détaille l'utilisation de l'image de conteneur du code LAMMPS téléchargeable à [cette adresse](/codes/scientific-computing/lammps/). En suivant ce lien, vous récupérez une image Apptainer (format de fichier `.sif`) qui vous permettra de créer des conteneurs à même de faire tourner LAMMPS.
 
@@ -111,7 +111,7 @@ apptainer exec --env OMP_NUM_THREADS=2 $HOME/apptainer-images/lammps.sif mpirun 
 
 Dans la commande précédente, on utilise la commande `mpirun` fournie par la version d'**OpenMPI** embarquée dans le conteneur pour communiquer directement avec le matériel de la machine hôte. Cette utilisation _embarquée_ présente un avantage majeur, puisque l'on utilise uniquement les outils installés dans le conteneur : elle fonctionne sur toutes les machines hôtes sans requérir d'installation. Néanmoins, la version d'**OpenMPI** présente au sein du conteneur n'est pas construite pour tourner de manière optimale sour toutes les machines hôtes, mais pour fourninr des performances satisfaisantes sur une gamme de machine aussi large que possible. Typiquement, dans le cas de Quantum Espresso, on observe que l'utilisation du processeur plafonne entre 85 et 90% en parallélisation embarquée. Par ailleurs, ce mode de parallélisation ne permet pas non plus d'effectuer du calcul distribué sur plusieurs nœuds de calcul. Si une facilité de portage au prix de performances légèrement dégradées peuvent convenir pour effectuer de simples essais sur une machine locale, ce n'est pas le cas sur une infrastructure de calcul haute performance.
 
-Dans le cas où les performances numériques sont centrales, il est recommandé d'utiliser un mode de parallélisation hybride, où l'on utilise la version d'**OpenMPI** de la machine hôte comme intermédiaire entre celle du conteneur et la matériel de la machine hôte. Pour plus de détails, veuillez consulter la [page dédiée](/documentation/use/apptainer_parallel/).
+Dans le cas où les performances numériques sont centrales, il est recommandé d'utiliser un mode de parallélisation hybride, où l'on utilise la version d'**OpenMPI** de la machine hôte comme intermédiaire entre celle du conteneur et la matériel de la machine hôte. Pour plus de détails, veuillez consulter la [page dédiée](/fr/documentation/use/apptainer-parallel/).
 
 ### Afficher l'aide
 

--- a/content/fr/documentation/by-container/ovito.md
+++ b/content/fr/documentation/by-container/ovito.md
@@ -8,7 +8,7 @@ weight: 2
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/documentation/install/install_apptainer/) pour plus de détails.
+En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/fr/documentation/install/install-apptainer/) pour plus de détails.
 
 Ce tutoriel détaille l'utilisation de l'image de conteneur du code Ovito téléchargeable à [cette adresse](/codes/visualisation/ovito/). En suivant ce lien, vous récupérez une image Apptainer (format de fichier `.sif`) qui vous permettra de créer des conteneurs à même de faire tourner Ovito.
 

--- a/content/fr/documentation/by-container/paraview.md
+++ b/content/fr/documentation/by-container/paraview.md
@@ -8,7 +8,7 @@ weight: 4
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/documentation/install/install_apptainer/) pour plus de détails.
+En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/fr/documentation/install/install-apptainer/) pour plus de détails.
 
 Ce tutoriel détaille l'utilisation de l'image de conteneur du code ParaView téléchargeable à [cette adresse](/codes/visualisation/paraview/). En suivant ce lien, vous récupérez une image Apptainer (format de fichier `.sif`) qui vous permettra de créer des conteneurs à même de faire tourner ParaView.
 

--- a/content/fr/documentation/by-container/quantum-espresso.md
+++ b/content/fr/documentation/by-container/quantum-espresso.md
@@ -8,7 +8,7 @@ weight: 3
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/documentation/install/install_apptainer/) pour plus de détails.
+En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/fr/documentation/install/install-apptainer/) pour plus de détails.
 
 Ce tutoriel détaille l'utilisation de l'image de conteneur du code Quantum Espresso téléchargeable à [cette adresse](/codes/scientific-computing/quantum-espresso/). En suivant ce lien, vous récupérez une image Apptainer (format de fichier `.sif`) qui vous permettra de créer des conteneurs à même de faire tourner Quantum Espresso.
 
@@ -115,7 +115,7 @@ apptainer exec --env OMP_NUM_THREADS=2 $HOME/apptainer-images/quantum-espresso.s
 
 Dans la commande précédente, on utilise la commande `mpirun` fournie par la version d'**OpenMPI** embarquée dans le conteneur pour communiquer directement avec le matériel de la machine hôte. Cette utilisation _embarquée_ présente un avantage majeur, puisque l'on utilise uniquement les outils installés dans le conteneur : elle fonctionne sur toutes les machines hôtes sans requérir d'installation. Néanmoins, la version d'**OpenMPI** présente au sein du conteneur n'est pas construite pour tourner de manière optimale sour toutes les machines hôtes, mais pour fourninr des performances satisfaisantes sur une gamme de machine aussi large que possible. Typiquement, dans le cas de Quantum Espresso, on observe que l'utilisation du processeur plafonne entre 85 et 90% en parallélisation embarquée. Par ailleurs, ce mode de parallélisation ne permet pas non plus d'effectuer du calcul distribué sur plusieurs nœuds de calcul. Si une facilité de portage au prix de performances légèrement dégradées peuvent convenir pour effectuer de simples essais sur une machine locale, ce n'est pas le cas sur une infrastructure de calcul haute performance.
 
-Dans le cas où les performances numériques sont centrales, il est recommandé d'utiliser un mode de parallélisation hybride, où l'on utilise la version d'**OpenMPI** de la machine hôte comme intermédiaire entre celle du conteneur et la matériel de la machine hôte. Pour plus de détails, veuillez consulter la [page dédiée](/documentation/use/apptainer_parallel/).
+Dans le cas où les performances numériques sont centrales, il est recommandé d'utiliser un mode de parallélisation hybride, où l'on utilise la version d'**OpenMPI** de la machine hôte comme intermédiaire entre celle du conteneur et la matériel de la machine hôte. Pour plus de détails, veuillez consulter la [page dédiée](/fr/documentation/use/apptainer-parallel/).
 
 ### Afficher l'aide
 

--- a/content/fr/documentation/by-container/vmd.md
+++ b/content/fr/documentation/by-container/vmd.md
@@ -8,7 +8,7 @@ weight: 4
 
 {{< callout context="note" title="" icon="tabler-icons/outline/info-circle" >}}
 
-En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/documentation/install/install_apptainer/) pour plus de détails.
+En préalable de ces explications, il est nécessaire d'avoir installé Apptainer sur votre machine ; voir [ce lien](/fr/documentation/install/install-apptainer/) pour plus de détails.
 
 Ce tutoriel détaille l'utilisation de l'image de conteneur du code VMD téléchargeable à [cette adresse](/codes/visualisation/vmd/). En suivant ce lien, vous récupérez une image Apptainer (format de fichier `.sif`) qui vous permettra de créer des conteneurs à même de faire tourner VMD.
 

--- a/content/fr/documentation/install/install-apptainer.md
+++ b/content/fr/documentation/install/install-apptainer.md
@@ -143,7 +143,7 @@ Toutefois, notez que pour exécuter Apptainer, la commande globale n'est pas dir
 
 ## Installation sur Windows / MacOS
 
-Pour les utilisateurs et utilisatrices Windows, une page de documentation dédiée est disponible [ici](/documentation/install/apptainer-windows).
+Pour les utilisateurs et utilisatrices Windows, une page de documentation dédiée est disponible [ici](/fr/documentation/install/apptainer-windows).
 
 Pour les utilisateurs Mac, il est recommandé d'utiliser Lima via Homebrew sur la [documentation d'Apptainer](https://apptainer.org/docs/admin/main/installation.html#mac).
 

--- a/content/fr/documentation/install/install-guix.md
+++ b/content/fr/documentation/install/install-guix.md
@@ -44,7 +44,7 @@ Si le sujet vous intéresse, nous vous conseillons de jeter un œil à cet [arti
 
 ## Installation sur Windows / MacOS
 
-Pour les utilisateurs et utilisatrices Windows, vous pouvez utiliser une [solution similaire](/documentation/install/apptainer-windows) à celle d'Apptainer et utiliser Windows Subsystem for Linux (WSL2). Attention, l'installation de Guix dans WSL est toutefois loin d'être triviale. Nous vous conseillons de suivre ce [guide](https://gist.github.com/giuliano108/49ec5bd0a9339db98535bc793ceb5ab4).
+Pour les utilisateurs et utilisatrices Windows, vous pouvez utiliser une [solution similaire](/fr/documentation/install/apptainer-windows) à celle d'Apptainer et utiliser Windows Subsystem for Linux (WSL2). Attention, l'installation de Guix dans WSL est toutefois loin d'être triviale. Nous vous conseillons de suivre ce [guide](https://gist.github.com/giuliano108/49ec5bd0a9339db98535bc793ceb5ab4).
 
 Pour les utilisateurs et utilisatrices MacOS, il est recommandé d'utiliser une machine virtuelle ou Docker. Vous pouvez consulter ce [lien](https://pagure.io/projects/MSG/%2A).
 


### PR DESCRIPTION
## Summary
- fix path to Apptainer install guide
- update Windows install links
- correct README file names

## Testing
- `npm run format` *(fails: SyntaxError in Prettier)*

------
https://chatgpt.com/codex/tasks/task_e_684f3508d85c832bbad28a4b25cef622