### PR TITLE
Fix English scientific-computing code layouts

### DIFF
--- a/content/en/codes/scientific-computing/abinit.md
+++ b/content/en/codes/scientific-computing/abinit.md
@@ -31,12 +31,17 @@ As an open-source project, Abinit benefits from an active community of developer
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### Abinit documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://www.abinit.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">Abinit documentation</h3>
 
-- #### <a href="https://docs.abinit.org/" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.abinit.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://docs.abinit.org/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/cp2k.md
+++ b/content/en/codes/scientific-computing/cp2k.md
@@ -24,12 +24,17 @@ The software supports various methodologies, including density functional theory
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### CP2K documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://www.cp2k.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">CP2K documentation</h3>
 
-- #### <a href="https://manual.cp2k.org/trunk/" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.cp2k.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://manual.cp2k.org/trunk/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/dftbplus.md
+++ b/content/en/codes/scientific-computing/dftbplus.md
@@ -22,12 +22,17 @@ apptainer pull dftbplus.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamon
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### DFTB+ documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://www.dftbplus.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">DFTB+ documentation</h3>
 
-- #### <a href="https://www.dftbplus.org/documentation.html" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.dftbplus.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://www.dftbplus.org/documentation.html" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/fenics.md
+++ b/content/en/codes/scientific-computing/fenics.md
@@ -23,12 +23,17 @@ apptainer pull fenics.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamond/
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### FEniCS documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://fenicsproject.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">FEniCS documentation</h3>
 
-- #### <a href="https://fenicsproject.org/documentation/" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://fenicsproject.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://fenicsproject.org/documentation/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/freefem.md
+++ b/content/en/codes/scientific-computing/freefem.md
@@ -31,12 +31,17 @@ With an active community and continuous development, FreeFEM remains at the fore
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### FreeFEM documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://freefem.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">FreeFEM documentation</h3>
 
-- #### <a href="https://doc.freefem.org/" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://freefem.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://doc.freefem.org/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/gmsh.md
+++ b/content/en/codes/scientific-computing/gmsh.md
@@ -27,12 +27,17 @@ Moreover, Gmsh includes a powerful scripting language that allows users to autom
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### Gmsh documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://gmsh.info/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">Gmsh documentation</h3>
 
-- #### <a href="https://gmsh.info/#Documentation" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://gmsh.info/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://gmsh.info/#Documentation" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/n2p2.md
+++ b/content/en/codes/scientific-computing/n2p2.md
@@ -22,12 +22,17 @@ apptainer pull n2p2.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamond/ap
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### n2p2 documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://github.com/CompPhysVienna/n2p2" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">n2p2 documentation</h3>
 
-- #### <a href="https://compphysvienna.github.io/n2p2/" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://github.com/CompPhysVienna/n2p2" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://compphysvienna.github.io/n2p2/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/neper.md
+++ b/content/en/codes/scientific-computing/neper.md
@@ -23,12 +23,17 @@ Neper is an advanced software designed for the modeling and simulation of polycr
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### Neper documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://neper.info/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">Neper documentation</h3>
 
-- #### <a href="https://neper.info/doc/index.html" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://neper.info/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://neper.info/doc/index.html" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/nwchem.md
+++ b/content/en/codes/scientific-computing/nwchem.md
@@ -23,12 +23,17 @@ apptainer pull nwchem.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamond/
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### NWChem documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://www.nwchem-sw.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">NWChem documentation</h3>
 
-- #### <a href="https://github.com/nwchemgit/nwchem/wiki" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.nwchem-sw.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://github.com/nwchemgit/nwchem/wiki" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/opencalphad.md
+++ b/content/en/codes/scientific-computing/opencalphad.md
@@ -31,12 +31,17 @@ In summary, OpenCalphad is a powerful, open-source tool for thermodynamic modeli
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### OpenCalphad documentation:
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://www.opencalphad.com/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">OpenCalphad documentation</h3>
 
-- #### <a href="https://www.opencalphad.com/OC6-macros.pdf" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.opencalphad.com/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://www.opencalphad.com/OC6-macros.pdf" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/opendis.md
+++ b/content/en/codes/scientific-computing/opendis.md
@@ -23,12 +23,17 @@ apptainer pull opendis.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamond
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### OpenDiS documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://opendis.github.io/OpenDiS/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">OpenDiS documentation</h3>
 
-- #### <a href="https://opendis.github.io/OpenDiS/tutorials/index.html" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://opendis.github.io/OpenDiS/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://opendis.github.io/OpenDiS/tutorials/index.html" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/plumed.md
+++ b/content/en/codes/scientific-computing/plumed.md
@@ -37,12 +37,17 @@ Additionally, Plumed supports a scripting interface that enables users to set up
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### PLUMED documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://www.plumed.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">PLUMED documentation</h3>
 
-- #### <a href="https://www.plumed.org/doc" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.plumed.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://www.plumed.org/doc" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/quantum-espresso.md
+++ b/content/en/codes/scientific-computing/quantum-espresso.md
@@ -25,14 +25,17 @@ The software supports various calculation methods, such as plane wave methods, q
 
 </div>
 
-### Tutorial
+<h3 class="mb-1">Tutorial</h3>
 
-#### <a href="/en/documentation/by-container/quantum-espresso">Learn how to use this specific container image</a>
+{{< link-card title="Learn to use this container image" href="/en/documentation/by-container/quantum-espresso" icon="tabler-icons/outline/package" class="mb-0" >}}
 
-### Quantum ESPRESSO documentation
+<h3 class="mb-1 mt-3">Quantum ESPRESSO documentation</h3>
 
-- #### <a href="https://www.quantum-espresso.org/" target="_blank">Official website</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.quantum-espresso.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://www.quantum-espresso.org/documentation/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### <a href="https://www.quantum-espresso.org/documentation/" target="_blank">Official documentation</a>
+<h3 class="mb-1 mt-3">Examples</h3>
 
-- #### <a href="/downloads/qe-tutorial-inputs.tar.gz">Examples: input files</a>
+{{< link-card title="Download input files" href="/downloads/qe-tutorial-inputs.tar.gz" icon="tabler-icons/outline/file-export" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/raspa2.md
+++ b/content/en/codes/scientific-computing/raspa2.md
@@ -23,12 +23,17 @@ apptainer pull raspa2.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamond/
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### RASPA2 documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://github.com/iRASPA/RASPA2" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">RASPA2 documentation</h3>
 
-- #### <a href="https://github.com/iRASPA/RASPA2/tree/master/Docs" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://github.com/iRASPA/RASPA2" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://github.com/iRASPA/RASPA2/tree/master/Docs" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/wannier90.md
+++ b/content/en/codes/scientific-computing/wannier90.md
@@ -23,12 +23,17 @@ apptainer pull wannier90.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamo
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### Wannier90 documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://wannier.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">Wannier90 documentation</h3>
 
-- #### <a href="https://github.com/wannier-developers/wannier90/tree/develop/docs" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://wannier.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://github.com/wannier-developers/wannier90/tree/develop/docs" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/xtb.md
+++ b/content/en/codes/scientific-computing/xtb.md
@@ -22,12 +22,17 @@ apptainer pull xtb.sif oras://gricad-registry.univ-grenoble-alpes.fr/diamond/app
 
 </div>
 
-### Learn how to use this specific container image _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### XTB documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://github.com/grimme-lab/xtb" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">XTB documentation</h3>
 
-- #### <a href="https://xtb-docs.readthedocs.io/" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://github.com/grimme-lab/xtb" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://xtb-docs.readthedocs.io/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/z-set.md
+++ b/content/en/codes/scientific-computing/z-set.md
@@ -36,12 +36,17 @@ Z-Set is widely used in academic research and industrial applications for its ro
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### Z-set documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="http://www.zset-software.com/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">Z-set documentation</h3>
 
-- #### <a href="http://www.zset-software.com/support/manuals/" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="http://www.zset-software.com/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="http://www.zset-software.com/support/manuals/" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}

--- a/content/en/codes/scientific-computing/zeo++.md
+++ b/content/en/codes/scientific-computing/zeo++.md
@@ -23,12 +23,17 @@ Zeo++ is a computational tool designed for the analysis and characterization of 
 
 </div>
 
-### Learn how to use this specific container _(to be added)_
+<h3 class="mb-1">Tutorial</h3>
 
-### Zeo++ documentation
+{{< link-card title="Content coming soon" description="<i>Learn to use this container image</i>" href="#bottom" icon="tabler-icons/outline/package" disabled="true" class="mb-0" >}}
 
-- #### <a href="https://www.zeoplusplus.org/" target="_blank">Official website</a>
+<h3 class="mb-1 mt-3">Zeo++ documentation</h3>
 
-- #### <a href="https://www.zeoplusplus.org/docs.html" target="_blank">Official documentation</a>
+{{< card-grid >}}
+{{< link-card title="Official website" href="https://www.zeoplusplus.org/" target="_blank" icon="tabler-icons/outline/world-www" class="mb-0" >}}
+{{< link-card title="Official documentation" href="https://www.zeoplusplus.org/docs.html" target="_blank" icon="tabler-icons/outline/book" class="mb-0" >}}
+{{< /card-grid >}}
 
-- #### Examples: input files _(to be added)_
+<h3 class="mb-1 mt-3">Examples</h3>
+
+{{< link-card title="Content coming soon" description="<i>Download input files</i>" href="#bottom" icon="tabler-icons/outline/file-export" disabled="true" class="mb-0" >}}


### PR DESCRIPTION
## Summary
- sync English code pages layout with French versions

## Testing
- `npm run format` *(fails: SyntaxError in flexsearch.js)*

------
https://chatgpt.com/codex/tasks/task_e_685543f5a3f4832b8ae2658d3ffb4195